### PR TITLE
fix: add missing header

### DIFF
--- a/utilities/gl-shader.hpp
+++ b/utilities/gl-shader.hpp
@@ -3,6 +3,7 @@
 
 #include <filesystem>
 #include <unordered_map>
+#include <vector>
 
 #include <GL/glew.h>
 #include <glm/glm.hpp>


### PR DESCRIPTION
<vector> header was missing, which caused issues on some non-debian based linux systems